### PR TITLE
2024_c1c2

### DIFF
--- a/aperture.m
+++ b/aperture.m
@@ -1,9 +1,9 @@
-function focus_new = aperture(focus_old,y,phi_tap)
+function focus_new = aperture(focus_old,y,struc)
 npart=size(y,2)/4;
 x = y(2*npart+1:npart*3);
 
 %% Aperture
-gapsize = phi_tap.aperture;
+gapsize = struc.gap;
 focus_new = focus_old.*(abs(x(1,:))<gapsize/2);
 
 end

--- a/apf_vs_gamma.m
+++ b/apf_vs_gamma.m
@@ -1,0 +1,80 @@
+% clear all
+close all
+
+%% conditions for transverse stability 
+lambda= 780e-9; k = 2*pi/lambda;
+
+E1 = 2e9;
+alpha = E1/(511e3*k);
+
+j = 1;
+%% APF beta
+psir = pi/4;
+for betagamma_exp = 1.0:0.03:2.4
+    betagamma(j) = 0.1*10^betagamma_exp;
+    i = 1;
+    for beatperiod= 20:20:3000
+        beatper(i) = beatperiod;
+        gamma = sqrt(1+betagamma(j).^2);
+        beta = sqrt(1 - 1./gamma.^2);
+        K_0 = sqrt(alpha*k^2./ gamma.^3 ./ beta.^2 * cos(psir));
+        fillfactor = 1;
+        L = beatperiod*fillfactor*lambda;
+        Ld = (1-fillfactor)*beatperiod*lambda/2;
+        O = [1 Ld; 0 1];
+        F = [cos(K_0.*L/4) 1./K_0.*sin(K_0.*L/4); -K_0.*sin(K_0.*L/4) cos(K_0.*L/4)];
+        D = [cosh(K_0.*L/4) 1./K_0*sinh(K_0.*L/4); K_0.*sinh(K_0.*L/4) cosh(K_0.*L/4)];
+        R = F*O*D*D*O*F;
+        R2 = D*O*F*F*O*D;
+        if(abs(trace(R))<2 & abs(trace(R2))<2)
+            beta_hat(i,j) = abs(real(R(1,2))/sqrt(1-R(1,1)^2));
+        else
+            beta_hat(i,j) = NaN;
+        end
+        i = i+1;
+    end
+    j = j+1;
+end
+
+%% Plot beta max
+figure(1);clf;
+
+[bg,bp] = meshgrid(betagamma,beatper);
+
+gap = 400e-9;
+norm_emit = 1e-9;
+sigma_max = sqrt(beta_hat./bg*norm_emit);
+
+mask = ones(size(sigma_max));indV = [];
+for ibp = 1:length(beatper)
+    ind0 = find(isnan(sigma_max(ibp,:)),1,'last');
+    if isempty(ind0); indV(ibp) = 1;else;indV(ibp) = ind0;end
+    mask(ibp,1:indV(ibp)) = NaN;
+end
+
+[envelope,iMinSigmamax] = min(sigma_max.*mask);
+contour(bg,bp,log10(sigma_max/gap),30)
+zindex = 0;
+hold on
+contour(bg,bp,log10(sigma_max/gap),[0 0],'LineWidth',2);
+plot(betagamma,beatper(iMinSigmamax));
+plot(betagamma(indV),beatper,'m');
+
+hold off
+legend('log10(sigma/400nm)')
+xlabel('relativistic gamma')
+ylabel('modulation period')
+title('Norm emittance 1 nm')
+colorbar
+%xlim([0.1 250])
+
+ind = find(sigma_max./gap<1);
+% bg(ind(end))
+LUT = beatper(iMinSigmamax);
+
+figure(2);clf;
+plot(bg,envelope*1e9,'k');
+xlabel('\beta\gamma')
+ylabel('Beam Envelope (nm)')
+%%
+% save(['LUT_APFstable_psiRes_',num2str(psir*1e4,'%3.0f')],'betagamma','E1','beatper','lambda','LUT')

--- a/calcTaper.m
+++ b/calcTaper.m
@@ -1,0 +1,26 @@
+function [taper, las, gam_res] = calcTaper(elec,struc,las,z,taperOn)
+%    
+    nstep = length(z); stepsize        = struc.zstop/(nstep-1);
+    gam_res=zeros(1,nstep);         beta_res=zeros(1,nstep);    
+    phi_add = zeros(1,nstep);       tap=zeros(1,nstep);
+    Ezfun           = @(c,x)((c(1)*exp(-struc.Gamma*x)+c(2)*exp(struc.Gamma*x)));
+
+    gam_res(1)=elec.gam0;
+    beta_res(1)=sqrt(1-1/gam_res(1)^2);
+    tap(1)=1/beta_res(1)-1+sin(las.thI)*las.k/struc.k;
+
+    phi_add(1) = struc.k.*tap(1)*(z(2)-z(1))/2;
+    % phi_add(1) = 0;
+    for i=2:nstep
+        gam_res(i)=gam_res(i-1)-las.G_gauss(i).*abs(Ezfun([struc.c1,struc.c2],struc.yc))/511e3*stepsize*sin(las.phi(i));
+        beta_res(i)=sqrt(1-1./gam_res(i).^2);
+        tap(i)=1/beta_res(max([i*taperOn,1]))-1+sin(las.thI)*las.k/struc.k;
+        phi_add(i) = trapz(z(2)-z(1),struc.k.*tap);
+    end
+
+    gradient_GeVperm = (gam_res(end)-gam_res(1))*0.511/struc.zstop*0.001;
+    maxenergy_MeV = gam_res(end)*0.511;
+    table(gradient_GeVperm,maxenergy_MeV)
+    las.phi     = las.phi + phi_add;
+    taper       = phi_add;
+end

--- a/dla_push.m
+++ b/dla_push.m
@@ -1,47 +1,48 @@
-function dy = dla_push(z,y,phi_tap,k,stepsize)
+function dy = dla_push(z,y,phi_tap,struc,stepsize)
 npart=size(y,2)/4;
+k = struc.k;
 
 %% Reshaping
 gamma=y(1:npart);
 tp=y(npart+1:npart*2);
 x = y(2*npart+1:npart*3);
 xp = y(3*npart+1:npart*4);
-
+beta = sqrt(gamma.^2-1)./gamma;
 
 %% Equations for particle motion
 dgamma = zeros([1,npart]);
 dxp = zeros([1,npart]);
+k_perpM = sqrt(phi_tap.kntap.^2-(k)^2);
 for jh = 1:phi_tap.nh
-    k_perp = sqrt(phi_tap.kntap(jh)^2-k^2);
+    k_perp = k_perpM(jh);
+%     k_perp = struc.Gamma;
+    Efield = phi_tap.Efft(jh)/phi_tap.nh;
     
+    transv  = (struc.c1*exp(-k_perp.*x)+struc.c2*exp(k_perp.*x));
+    transvd =   -struc.c1*exp(-k_perp.*x)+struc.c2*exp(k_perp.*x);
+
     if phi_tap.linearizedfields
-        dgamma = dgamma-1/511e3*abs(phi_tap.Efft(jh)/phi_tap.nh).*sin(tp+(phi_tap.kntap(jh)-k).*z+angle(phi_tap.Efft(jh))); %.*cosh(k_perp.*x);
-        dxp = dxp + 1/511e3.*x./gamma.*(1-phi_tap.betantap(jh).*sqrt(gamma.^2-1)./gamma)*phi_tap.kntap(jh).*...
-            abs(phi_tap.Efft(jh)/phi_tap.nh).*cos(tp+(phi_tap.kntap(jh)-k).*z+angle(phi_tap.Efft(jh)));
-        
-    else 
-        dgamma = dgamma-1/511e3*abs(phi_tap.Efft(jh)/phi_tap.nh).*sin(tp+(phi_tap.kntap(jh)-k).*z+angle(phi_tap.Efft(jh))).*cosh(k_perp.*x);
+        dgamma = dgamma - abs(struc.c1+struc.c2).*1/511e3*imag(Efield.*exp(1i*(tp+(phi_tap.kntap(jh)-k).*z)));
+        dxp = dxp +  abs(struc.c1+struc.c2).*1/511e3.*x./gamma.*(1-phi_tap.betantap(jh).*beta)*phi_tap.kntap(jh).*...
+            real(Efield.*exp(1i*(tp+(phi_tap.kntap(jh)-k).*z)));
+    else
+        dgamma = dgamma - 1/511e3*imag(Efield.*transv.*exp(1i*(tp+(phi_tap.kntap(jh)-k).*z)));
         if(k_perp ~= 0)
-            dxp = dxp + 1/511e3.*abs(sinh(k_perp.*x)./k_perp)./gamma.*(1-phi_tap.betantap(jh).*sqrt(gamma.^2-1)./gamma)*phi_tap.kntap(jh).*...
-                abs(phi_tap.Efft(jh)/phi_tap.nh).*cos(tp+(phi_tap.kntap(jh)-k).*z+angle(phi_tap.Efft(jh)));
+            dxp = dxp + 1/511e3.*(1-phi_tap.betantap(jh).*beta)./gamma*...
+                phi_tap.kntap(jh).*...
+                real(Efield.*transvd./k_perp.*exp(1i*(tp+(phi_tap.kntap(jh)-k).*z)));
         else
-            dxp = dxp + 1/511e3.*x./gamma.*(1-phi_tap.betantap(jh).*sqrt(gamma.^2-1)./gamma)*phi_tap.kntap(jh).*...
-                abs(phi_tap.Efft(jh)/phi_tap.nh).*cos(tp+(phi_tap.kntap(jh)-k).*z+angle(phi_tap.Efft(jh)));
+            dxp = dxp + 1/511e3.*x./gamma.*(1-phi_tap.betantap(jh).*beta)*...
+                phi_tap.kntap(jh).*...
+                real(Efield.*transv.*exp(1i*(tp+(phi_tap.kntap(jh)-k).*z)));
         end
-        dgamma(abs(x*k_perp)>phi_tap.aperture*max(real(k_perpM))) = 0;
-        dxp(abs(x*k_perp)>phi_tap.aperture*max(real(k_perpM))) = 0;
+
+        dgamma(abs(x*k_perp)>struc.gap*max(real(k_perpM))) = 0;
+        dxp(abs(x*k_perp)>struc.gap*max(real(k_perpM))) = 0;
     end
-dtp = k*(1-gamma./sqrt(gamma.^2-1));
-dx = xp;
+    dtp = k*(1-1./beta);
+    dx = xp;
 
 %% Function output
 dy = [dgamma dtp dx dxp];
 end
-
-
-
-
-
-
-
-

--- a/dla_push_RK4.m
+++ b/dla_push_RK4.m
@@ -1,13 +1,11 @@
-function [ynew,focus_new] = dla_push_RK4(zold,yold,phi_tap,k,stepsize,focus)
-focus_new = aperture(focus,yold);
+function [ynew,focus_new] = dla_push_RK4(zold,yold,phi_tap,struc,stepsize,focus)
+focus_new = aperture(focus,yold,struc);
 
-k1=stepsize*dla_push(zold,yold,phi_tap,k,stepsize);
-k2=stepsize*dla_push(zold+stepsize/2,yold+k1/2,phi_tap,k,stepsize);
-k3=stepsize*dla_push(zold+stepsize/2,yold+k2/2,phi_tap,k,stepsize);
-k4=stepsize*dla_push(zold+stepsize,yold+k3,phi_tap,k,stepsize);
+k1=stepsize*dla_push(zold,yold,phi_tap,struc,stepsize);
+k2=stepsize*dla_push(zold+stepsize/2,yold+k1/2,phi_tap,struc,stepsize);
+k3=stepsize*dla_push(zold+stepsize/2,yold+k2/2,phi_tap,struc,stepsize);
+k4=stepsize*dla_push(zold+stepsize,yold+k3,phi_tap,struc,stepsize);
 
 ynew=yold+1/6*(k1+2*k2+2*k3+k4);
 end
-
-
 

--- a/genParts.m
+++ b/genParts.m
@@ -1,0 +1,40 @@
+function [y,frac] = genParts(elec,psi_res, bunching,struc)
+    sigmaxp = elec.emit/elec.gam0/elec.beta0/elec.sigmax;
+    seed = 1;
+    rng(135);
+   
+    nK      = 0;
+    yK      = [];
+    nTot    = 0;
+    while nK < elec.n
+        theta0 = hammersley(1,elec.n,seed)*2*pi-pi;
+        gamma0 = normrnd(elec.gam0,elec.deltagamma,[1,elec.n]);
+        % add bunching
+        if bunching
+             Ab = 5*elec.deltagamma;
+             R56 = pi/Ab/2;
+             gamma0 = gamma0 - Ab.*sin(theta0);
+             theta0 = theta0+(gamma0-mean(gamma0)).*R56-psi_res(1)-pi;
+        else
+                theta0 = hammersley(1,elec.n,seed)*2*pi-pi;
+        end
+
+        x0 = normrnd(0,elec.sigmax,[1,elec.n]);
+        x0p = normrnd(0,sigmaxp,[1,elec.n]);        
+
+        filt = (abs(x0)<struc.gap/2);
+        gamma0 = gamma0(filt);
+        x0 = x0(filt);
+        x0p = x0p(filt);
+        hold on;    
+        yK0 = [gamma0; x0; x0p];
+        yK  = [yK yK0];
+        nK = length(yK);
+        nTot = nTot + elec.n;
+    end
+    frac = nK/nTot;
+    y = yK(:,1:elec.n);
+    y = [y(1,:) theta0(1:elec.n) y(2,:) y(3,:)];
+end
+
+

--- a/hammersley.m
+++ b/hammersley.m
@@ -46,4 +46,3 @@ for k=1:D-1 % dimensions
 end
 
 S = S';
-

--- a/shard_inputs.m
+++ b/shard_inputs.m
@@ -1,0 +1,301 @@
+%% Input for shard_main_noPlots
+% clear all;      close all;
+plots           = true;     set(0, 'DefaultAxesFontSize', 6.5);
+plotParticleDists = true;
+saveTag         = false;
+animation       = false;
+
+% bOff = 0;
+% fName           = ['shard_buncher_opt_gamma12p_L5_noTaper_bOff_',num2str(floor(bOff*1e3))];
+% fName           = ['shard_buncher_opt_gamma17p_L5_noTaper_bOff_',num2str(floor(bOff*1e3))];
+% fName           = 'shard_Pond_gamma12_tapered_fig1';
+% fName           = 'shard_mpPond_gamma12_untapered_fig1';
+
+%% Structure
+struc.c1        = 0.1;     % Ideal
+struc.c2        = 0.1;
+% struc.c1        = 0.025; % data
+% struc.c2        = 0.025;
+struc.zstop     = 5e-3;
+% struc.zstop     = 1.28e-3;
+struc.gap       = 400e-9;   % Ideal
+% struc.gap       = 1200e-9;% data
+struc.lambda    = 780e-9;
+
+
+ %% Electrons
+elec.kin          = (12 - 1)*511e3; % Exp: gamma 12, gamma 17.14
+ 
+elec.emit         = 200e-9;  % Normalized
+elec.deltagamma   = 0.0005;  % gam0*()
+elec.sigmax       = 30e-6;  
+
+elec.emit         = 1e-9;
+elec.deltagamma   = 0*0.0005;  % gam0*()
+elec.sigmax       = 1e-6;  
+
+bunching        = false;     % Prebunch beam
+
+elec            = calcElec(elec);
+[struc,Ezfun]   = calcStruc(struc, elec); % (need beta0)
+%% Simulation
+elec.n          = 500;
+nfreq           = 2^7;                                      % Number of Spatial Harmonics
+
+opt             = true;                                   % Removes Particles as they hit the walls
+
+nstep           = floor(struc.zstop/struc.lambda/25)*4;    % zstop/nstep should be an integer multiple of lambda
+stepsize        = struc.zstop/(nstep-1);
+z               = 0:stepsize:struc.zstop;
+%% Inputs:
+las.sigma       = 5e-3;
+
+% Ponderomotive:
+las.thI         = 0e-04; % angle incidence
+las.E0          = 10e9;
+taperOn         = true;
+bOff            = 0;
+pondTag         = 1;
+constPsi        = 30; % resonant phase
+apfTag          = 0;
+phiSmooth       = false;
+lambdap         = [linspace(400e-6,600e-6,sum(z<1e-3)),linspace(600e-6,860e-6,sum(z>=1e-3))];
+buncher         = true;
+
+% Flat:
+% las.thI         = -3.1e-04; % angle incidence = mean(tap(z<2) - tap(1)) when taperOn = true 
+% las.E0          = 2.4e9;
+% taperOn   = false;
+% bOff            = 0;
+% pondTag         = 0;
+% apfTag          = 0;
+% constPsi        = 60; % resonant phase
+% hardCodeBuncher = true;
+
+% Tapered
+% las.thI         = 0e-04; % angle incidence = mean(tap(z<2) - tap(1)) when taperOn = true 
+% las.E0          = 1e9;
+% taperOn   = false;
+% % bOff            = 2*pi;
+% pondTag         = 0;
+% apfTag          = 0;
+% constPsi        = 90; % resonant phase
+% phiSmooth       = true;
+% Ap              = 0; lambdap = 1;
+% las.E0          = 1e9;
+% 
+% elec.kin          =(17.14-1)*511e3;
+% st              = 0.64e-3;
+% dr              = 0;
+% elec.kin          =(12-1)*511e3;
+% st              =  1.7e-3;
+% dr              = 1.28e-3;
+
+% APF:
+% las.thI         = 0e-04; % angle incidence
+% las.E0          = 10e9;
+% taperOn         = true;
+% bOff            = 0*pi/8;
+% pondTag         = 0;
+% apfTag          = true;
+% apfFrac         = 3;
+% ratio           = 0.5;
+% constPsi        = 90 - apfTag*pi/apfFrac*180/pi; % resonant phase
+% % % lambdap         = [ones(1,sum(z<1e-3)),linspace(600,600,sum(z>=1e-3))].*struc.lambda;
+% % % lambdap         = [ones(1,sum(z<1e-3)),linspace(600,1400,sum(z>=1e-3))].*struc.lambda;
+% % lambdap         = [ones(1,sum(z<1e-3)),linspace(600,1600,sum(z>=1e-3))].*struc.lambda;
+% phiSmooth       = false;
+% % lambdap         = [ones(1,sum(z<1e-3)),linspace(842,1775,sum(z>=1e-3))].*struc.lambda;
+% buncher        = true;
+% load(['LUT_APFstable_psiRes_',num2str(pi/apfFrac*1e4,'%3.0f')])
+% LUTsubset = LUT(betagamma>=elec.gam0.*elec.beta0);
+% betagammaSub = betagamma(betagamma>=elec.gam0.*elec.beta0);
+% apfFit = polyfit(betagammaSub,LUTsubset,1);
+% lambdap1        = elec.gam0.*elec.beta0*apfFit(1)+apfFit(2);
+% lambdap2        = 16*apfFit(1)+apfFit(2);
+% % lambdap         = [ones(1,sum(z<1e-3)),linspace(1200,1200,sum(z>=1e-3))].*struc.lambda;
+% lambdap         = [ones(1,sum(z<1e-3)),linspace(lambdap1,lambdap2,sum(z>=1e-3))].*struc.lambda;
+
+% Buncher
+% las.thI         = -0*2.8e-04; % angle incidence
+% las.E0          = 1e9;
+% taperOn   = false;
+% % bOff            = pi;
+% pondTag         = 0;
+% apfTag          = 0;
+% constPsi        = 90; % resonant phase
+% lambdap         = 1.5e-3*1/1.65;
+% E0end           = 1e-3;
+%Smoothing
+sigma = 10e-6/stepsize;                             % pick sigma value for gaussian PSF of optical system
+
+%% Laser
+las.lambda      = 780e-9; las.delT = 100e-15;
+las.k           = 2*pi/las.lambda;
+
+% Phase
+res             = (-pondTag)*ones(1,nstep);
+psi_res         = -pi/180*constPsi*ones(1,nstep);
+
+st = 0; dr = 0; % Default to no buncher
+if apfTag % APF Based
+    if buncher 
+        st              = 0.06e-3; 
+        dr              = 1.2e-3 - st;
+    end
+        psi_res(z<(dr+st)) = -pi;
+        psi_res(z<(st))     = 0;
+        psi_res(z>=(st+dr)&mod(z-dr-st,lambdap)./lambdap<ratio) = -pi - psi_res(z>=(st+dr)&mod(z-dr-st,lambdap)./lambdap<ratio);
+elseif pondTag % Ponderomotive Based:
+    if buncher
+        st = 0.05e-3;     dr              = 1e-3 - st;
+    end
+    res(z<=st)             = 0;
+    psi_res(z<=(st)) = 0;
+elseif buncher
+        st = 0.1; dr = 1e-3 - st;
+end
+
+LTot            = struc.zstop; % limits laser end
+
+% Amplitude Ponderomotive Accel
+captL           = dr + st; bL = captL;
+Ap              = zeros(1,nstep);
+Ap(z<captL)     = 0;
+Ap(z>=captL)    = linspace(0.55,0.3,sum(z>=captL));
+% Ap(z>=bL&z<=5e-3)    = linspace(0.05,0.35,sum(z>=bL&z<=5e-3));
+% Ap(z>=5e-3)    = linspace(0.35,0.05,sum(z>=5e-3));
+
+% Calculation
+psi_res(res==-1)= psi_res(res==-1) - pi;          % resonant phase for ponderomotive case
+las.phi     = psi_res + pondTag*Ap.*cos(2*pi.*(z- st-dr)./lambdap)-res.*2*pi.*(z- st-dr)./lambdap;      % Ponderomotive
+
+las.phi(z>(st)) = las.phi(z>(st)) + bOff; phi0 = las.phi(1);
+% las.phi         = unwrap(mod(las.phi,2*pi)); %make phase continuous
+% las.phi         = las.phi - las.phi(1) + phi0;
+
+% Amplitude
+las.G_gauss     = las.E0*exp((-(z-struc.zstop/2).^2)/(2*las.sigma^2));
+bR              = (z>st) & (z<(st+dr));
+aR              = (z>=(st+dr));
+las.G_gauss(bR) = las.G_gauss(bR)/100;
+las.G_gauss(z>LTot) = 0;
+
+%  Spatial resolution filtering
+sigma = 10e-6/stepsize;                             % pick sigma value for gaussian PSF of optical system
+gaussFilter = gausswin(round(6*sigma + 1))';
+gaussFilter = gaussFilter / sum(gaussFilter);       % normalization
+las.G_gauss1 = conv(las.G_gauss, gaussFilter, 'same');     % Apply filter
+las.G_gauss1(1:10) = las.G_gauss(1:10);
+las.G_gauss1(end-9:end) = las.G_gauss(end-9:end);
+las.G_gauss =  las.G_gauss1;
+
+if phiSmooth
+    sigma = 10e-6/stepsize;                             % pick sigma value for gaussian PSF of optical system
+gaussFilter = gausswin(round(6*sigma + 1))';
+gaussFilter = gaussFilter / sum(gaussFilter);       % normalization
+    phi1 = las.phi(end);
+    las.phi = conv(las.phi, gaussFilter, 'same');
+    las.phi(1:ceil(length(gaussFilter/2))) = phi0;
+    las.phi(end - ceil(length(gaussFilter/2)) + 1:end) = phi1;
+end
+ 
+%%
+plotGPhi(z,las.G_gauss*1e-6,las.phi,1,false);
+
+%% Calculates phase to match accelerating electrons (or not(taperOn))
+[taper, las, gam_res]  = calcTaper(elec,struc,las,z,taperOn);
+
+%% Generate Particles
+[yold,frac]     = genParts(elec,psi_res, bunching,struc);
+% yold(elec.n+1:2*elec.n) = (pi + yold(elec.n+1:2*elec.n))/3 - 0.7;
+drawnow;
+
+%% Run Simulation
+shard_main_noPlots; 
+
+%% Output: gammap,thetap,x,xp, focusTrack
+capt            = 0.511*(gammap(end,:) - elec.gam0)>(0.9*0.511*(gam_res(end)-elec.gam0));
+focus           = logical(focus); focused = sum(focus);
+
+capt            = capt&focus; accelFoc = sum(capt);
+target          = sum(capt.*focus*(gam_res(end)-elec.gam0));
+norm            = npart*(gam_res(end)-elec.gam0);
+target          = target/norm;
+if sum(capt)==0; capt=focus;end
+inow            = nstep;
+clear captured rejected cap_phase rej_phase
+
+if ~opt
+        capturedGm = gammap(inow,:);
+        rejectedGm = gammap(inow,:);
+        capturedGm(~focus) = NaN;
+        rejectedGm(focus) = NaN;
+
+        capturedTp = thetap(inow,:);
+        rejectedTp = thetap(inow,:);
+        capturedTp(~focus) = NaN;
+        rejectedTp(focus) = NaN;
+        
+        cap_phase = xp(inow,:);
+        rej_phase = xp(inow,:);
+        cap_phase(~focus) = NaN;
+        rej_phase(focus) = NaN;
+    else
+        capturedGm = gammap;
+        rejectedGm = NaN;
+        capturedTp = thetap;
+        rejectedTp = NaN;
+        cap_phase = xp;
+        rej_phase = NaN;
+    end
+disp(['Focused Particles = ' num2str(sum(focus))])
+disp(['Total captured particles =' num2str(sum(capt.*focus))])
+disp(['Target cost function =' num2str(target)])
+disp(['Phase Offset = ' num2str(bOff)]);
+disp(['Resonant Energy Gain (in keV) = ' num2str((gam_res(end)-elec.gam0)*511)])
+disp(['Maximum Energy Gain (in keV) = ' num2str(max(gammap(end,focus)-gammap(1,focus))*511)])
+disp(['Maximum Energy Loss (in keV) = ' num2str(min(gammap(end,focus)-gammap(1,focus))*511)])
+%%
+if saveTag
+    if ~opt
+        save(fName,'struc','gam_res','DATA','focus','bOff','gammap','thetap','elec','las','taper','Ap','lambdap')
+    else
+        save(fName,'struc','gam_res','focus','bOff','gammap','thetap','elec','las','taper','Ap','lambdap')
+    end
+end
+%%
+if plots
+    shard_quickPlots;
+end
+%%
+function elec = calcElec(elec)
+    % Must define elec.kin, elec.deltagamma
+    elec.E0         = elec.kin+511e3;
+    elec.gam0       = elec.E0/511e3;
+    elec.beta0      = sqrt(1-1/elec.gam0^2);
+    elec.deltagamma = elec.gam0*elec.deltagamma;
+end
+
+function [struc, Ezfun] = calcStruc(struc, elec)
+    % Must define struc.lambda,struc.c1,c2, elec.beta0
+    struc.Gamma     = 2*pi*sqrt(1/struc.lambda^2-(1/(struc.lambda/elec.beta0))^2);
+    struc.yc        = log(abs((struc.c1)./(struc.c2)))./(2*struc.Gamma);
+    struc.k         = 2*pi/struc.lambda;
+    Ezfun           = @(c,x)((c(1)*exp(-struc.Gamma*x)+c(2)*exp(struc.Gamma*x)));
+    struc.sf        = abs(Ezfun([struc.c1,struc.c2],struc.yc));
+end
+
+%%
+function plotGPhi(z,G,phi,fig,holdTag)
+    figure(fig);
+    if holdTag; hold on;
+    else; clf; end
+    yyaxis left
+    plot(z*1e3,G,'LineWidth',1.5);
+    xlabel('z (mm)');
+    ylabel('G (MeV/m)')
+    yyaxis right
+    plot(z*1e3,phi,'LineWidth',1.5)
+    ylabel('\phi (rad)')
+end

--- a/shard_main_noPlots.m
+++ b/shard_main_noPlots.m
@@ -1,0 +1,95 @@
+%% DLA Simulation for SLM Phase Profile SHARD ver 2024
+% SHarD Spatial HARmonic DLA simulation
+% Assumes single frequency for laser 
+
+% Shard Version 2022. Arbitrary on axis phase and amplitude profile
+% are Fourier-analyzed to generate a set of spatial harmonics to describe
+% the field in the DLA gap
+
+% Shard Version 2023 uses a better model for the fields in the DLA structures
+% which are defined in terms of two complex constant c1 and c2
+% This allows to simulate deflecting modes, dipole kicks as well as not symmetric focusing
+% channels. 
+
+% Update: this file no longer plots. 
+% Update: this file no longer calculates taper, input taper
+
+% Inputs: laser (phase + amplitude), elec (parameters), 
+% y0 (initial electron distribution), opt (T if tracking
+% all particles, F if throwing away particles as they hit the wall)
+% Output: gammap,thetap,x,xp, focusTrack
+%% Input Parameters
+linearizedfields = true;
+npart = elec.n;             % Number of particles
+
+%% Spatial Harmonics Fourier Analysis
+E_axis = las.G_gauss.*exp(1i.*las.phi);
+dwnsamplerate = max(ceil(nstep/nfreq),1);
+E_axis_dn = downsample(E_axis,dwnsamplerate);
+dnL0       = length(E_axis_dn);
+E_axis_dn = [E_axis_dn, zeros(1,mod(dnL0,2))]; % pad to even
+Efft = fftshift(fft(E_axis_dn));
+[~,idx] = max(abs(Efft));
+nh = size(Efft,2)
+kmax = pi/(struc.zstop/nstep*dwnsamplerate);
+deltak = kmax/(nh/2);  
+kshift = (-nh/2:nh/2-1)*deltak; % zero-centered frequency range
+
+for jh = 1:nh
+    kntap(jh) = struc.k + kshift(jh);    
+    betantap(jh) = struc.k ./ kntap(:,jh);
+    gammantap(jh) = sqrt(1./(1-betantap(:,jh).^2));
+end
+
+phi_tap.nh = nh;
+phi_tap.kntap = kntap;
+phi_tap.betantap = betantap;
+phi_tap.Efft = Efft;
+phi_tap.linearizedfields = linearizedfields;
+
+%% Tracking
+focus = ones([1,npart]);
+
+tic
+if opt
+    i = 0;
+    while (i<nstep)
+        i = i+1;
+        [ynew, focus_new]=dla_push_RK4(z(i),yold,phi_tap,struc,stepsize,focus);
+        filt0 = (1==(repmat(focus_new,1,4)));
+        ynew = ynew(filt0~=0);
+        yold =ynew;
+        focus = ones([1,length(yold)/4]);
+    end
+else
+    focusTrack = ones([nstep,npart]);
+    DATA(1,:)=yold;
+    for i=1:nstep
+        [ynew, focus_new]=dla_push_RK4(z(i),yold,phi_tap,struc,stepsize,focus);
+        DATA(i+1,:)=ynew;
+        yold=ynew;
+        focus = focus_new;
+        focusTrack(i,:) = focus;
+    end
+end
+toc
+
+%% Outputs
+if 1==opt
+    npartN = length(yold)/4;
+    gammap= real(ynew(1:npartN));
+    thetap= real(ynew(npartN+1:2*npartN));
+    x = ynew(2*npartN+1:3*npartN);
+    xp = ynew(3*npartN+1:4*npartN);
+    focusTrack = focus;
+else
+    DATA = real(DATA);
+    gammap = zeros(nstep,npart);thetap = zeros(nstep,npart);
+    x = zeros(nstep,npart);     xp = zeros(nstep,npart);
+    for i = 1:nstep
+        gammap(i,:)= DATA(i,1:npart);
+        thetap(i,:)= DATA(i,npart+1:2*npart);
+        x(i,:)= DATA(i,2*npart+1:3*npart);
+        xp(i,:)= DATA(i,3*npart+1:4*npart);
+    end
+end

--- a/shard_quickPlots.m
+++ b/shard_quickPlots.m
@@ -1,0 +1,292 @@
+%% SHarD Quick Plots
+
+%%
+E_axis_dn_reconstructed = ifft(ifftshift(Efft));
+
+G_gauss_approx = abs(E_axis_dn_reconstructed);
+phi_approx = unwrap(angle(E_axis_dn_reconstructed));
+z_reconstructed = downsample(z,dwnsamplerate);
+
+figure(1); clf;
+subplot(1,2,1)
+plot(kshift,abs(Efft));
+title('Spatial Harmonics Content')
+
+subplot(1,2,2)
+yyaxis left
+plot(z_reconstructed,G_gauss_approx(1:dnL0),'.'); hold on;
+plot(z,las.G_gauss);
+yyaxis right
+plot(z_reconstructed,phi_approx(1:dnL0),'.');
+hold on;
+plot(z,las.phi)
+title('Field Comparison')
+L = legend('Reconstructed', 'Input');
+L.Location = 'Southeast';
+%%
+if plotParticleDists
+    figure(3); clf;
+    plot(x(1,focus)*1e6,xp(1,focus)*1e3,'bo');hold on;
+    plot(x(1,~focus)*1e6,xp(1,~focus)*1e3,'ro')
+    if ~opt
+        plot(x(end,:)*1e6,cap_phase*1e3,'b.','MarkerSize',10)
+    end
+    xline(-struc.gap/2*1e6,'LineWidth',2);    xline(struc.gap/2*1e6,'LineWidth',2);
+    xlim([-2*struc.gap/2*1e6,2*struc.gap/2*1e6])
+    legend('z = 0 (Transmitted)','z = 0 (Walls)','z = end (Transmitted)')
+    
+    xlabel('y [\mum]')
+    ylabel('y''[mrad]')
+    ylim([-1,1])
+    
+    if ~opt
+        iPs = [1,nstep];
+    else
+        iPs = 1;
+    end
+    figure(4);clf;
+    for ii = 1:length(iPs)
+        iP = iPs(ii);
+        subplot(1,length(iPs),ii)
+        scatter((x(iP,~focus))*1e6,mod(thetap(iP,~focus)+taper(iP) - pi,2*pi) - pi,'ro'); hold on;
+        plot((x(iP,focus))*1e6,mod(thetap(iP,focus)+taper(iP) - pi,2*pi) - pi,'go'); 
+        plot((x(iP,capt))*1e6,mod(thetap(iP,capt)+taper(iP) - pi,2*pi) - pi,'bo'); hold off;
+        xline(-struc.gap*1e6*.5,'LineWidth',2);
+        xline(struc.gap*1e6*.5,'LineWidth',2);
+        xlim([-2*struc.gap/2*1e6,2*struc.gap/2*1e6])
+        ylim([-pi,pi])
+        xlabel('y [\mum]')
+        ylabel('phi [rad]')
+        title(['z = ',num2str(z(iP)*1e3),' mm'])
+    end
+end
+%%
+binLims = .511*[0.95*min(gammap(end,focus)-elec.gam0),1.05*max(gammap(end,focus)-elec.gam0)];
+
+if binLims(1)>binLims(2); binLims = flip(binLims);end
+
+f = figure(5); clf; f.Units  = 'centimeters';
+set(gcf,'renderer','Painters')
+f.Position = [1,1,12,8];
+histogram(.511*gammap(end,focus)-(elec.gam0*.511),'NumBins',50,'BinLimits',binLims,'FaceColor','r'); 
+ylabel('Count')
+
+%%
+if ~opt
+    figure(6);clf;
+    if sum(focus)>1
+        plot(z*1e3, .511*max(gammap(:,focus)-elec.gam0,[],2)); hold on;
+    else
+        plot(z*1e3, .511*max(gammap(:,:)-elec.gam0,[],2)); hold on;
+    end
+    plot(z*1e3,real((gam_res-elec.gam0)*0.511),'--'); hold off;
+    legend('Simulation','Model')
+    title('Maximum Energy Particle')
+    ylabel('Energy (MeV)')
+    xlabel('z (mm)')
+end    
+
+%%
+[~,iP] = maxk(gammap(end,focus),10);
+gpF = gammap(:,focus);xF = x(:,focus);
+
+%% Change in phase over course of structure (Longitudinal Stability)
+if ~opt
+    fCapt = find(capt);
+    xPl = 1e3*z'; xPlx = [xPl,xPl];
+    thF = thetap(:,focus);
+
+    figure(7); clf; 
+    set(gcf,'renderer','Painters')
+
+for iPlot = 1:min([10,sum(capt)])
+    yPl = (thF(:,iP(iPlot)) + taper'); yPly = [yPl, yPl];
+    zPlz = zeros(size(xPlx));
+    cols = .511*(gpF(end,iP(iPlot)) - gpF(1,iP(iPlot)))*ones(size(yPly));
+    hs = surf(xPlx,yPly,zPlz,cols,'EdgeColor','Interp'); hold on;
+    hs.LineWidth = 1;
+end
+view(2)
+a = colorbar;
+ylabel(a,'\Delta E (MeV)','fontsize',16,'Rotation',90);
+a.Label.Position(1) = 3.5;
+xlabel('z (mm)')
+ylabel('\phi (rad)')
+grid off
+box on
+end
+
+%% Energy, Transverse Position along structure
+if ~opt
+f = figure(8);clf;
+set(gcf,'renderer','Painters')
+f.Units  = 'centimeters';
+f.Position = [5,5,14,10];
+% hannah = [
+%      21, 173, 173;
+%      62, 138,  61;
+%      172,  13,  27;
+%     ]./256;
+% nColors = 256*8;
+% cmapSurf = zeros(nColors,3);
+% for i = 1:3
+%     cmapSurf(1:nColors/2, i) = linspace(hannah(1,i),hannah(2,i), nColors/2);
+% end
+% for i = 1:3
+%     cmapSurf(nColors/2+1:nColors, i) = linspace(hannah(2,i),hannah(3,i), nColors/2);
+% end
+rainbowColormap;
+for ii = 1:1:min([length(iP),50])
+xx=[z*1e3; z*1e3];           %// create a 2D matrix based on "X" column
+yy=[1e9*xF(:,iP(ii)), 1e9*xF(:,iP(ii))]';           %// same for Y
+zz=zeros(size(xx)); %// everything in the Z=0 plane
+cc =[.511*(gpF(:,iP(ii))-elec.gam0), .511*(gpF(:,iP(ii))-elec.gam0)]';         %// matrix for "CData"
+hold on;
+hs=surf(xx,yy,zz,cc,'EdgeColor','interp','FaceColor','none') ;
+hs.LineWidth = 1.5;
+view(2)
+colormap(flip(rainbowCMap))
+end
+grid off
+ylabel('y (nm)')
+xlabel('z (mm)')
+c = colorbar;
+yl = ylabel(c,'\Delta{E} (MeV)','Rotation',90);
+%     saveas(gcf,['C:\Users\sophi\Documents\UCLA Grad\ACHIP\2023_2024_Run\Paper\MatlabFigures\shard_Pond_traj_bunched'],'epsc')
+%     saveas(gcf,['C:\Users\sophi\Documents\UCLA Grad\ACHIP\2023_2024_Run\Paper\MatlabFigures\shard_Pond_traj_bunched'],'pdf')
+%         saveas(gcf,['C:\Users\sophi\Documents\UCLA Grad\ACHIP\2023_2024_Run\Paper\MatlabFigures\shard_Pond_traj_bunched'],'png')
+end
+%% Change in position over course of structure (Transverse Stability)
+% if ~opt
+% xPl = 1e3*z'; xPlx = [xPl,xPl];
+% 
+% figure(9); clf; 
+% set(gcf,'renderer','Painters')
+% 
+% for iPlot = 1:1:sum(capt)
+%     iCapt = fCapt(iPlot);
+%     yPl = 1e6*x(:,iCapt); yPly = [yPl, yPl];
+%     zPlz = zeros(size(xPlx));
+%     cols = .511*(gammap(end,iCapt) - gammap(1,iCapt))*ones(size(yPly));
+%     hs = surf(xPlx,yPly,zPlz,cols,'EdgeColor','Interp'); hold on;
+%     hs.LineWidth = 1;
+% end    
+% 
+% view(2)
+% a = colorbar;
+% ylabel(a,'\Delta E (MeV)','fontsize',16,'Rotation',90);
+% a.Label.Position(1) = 3.5;
+% xlabel('z (mm)')
+% ylabel('y (\mu{m})')
+% grid off
+% box on
+% end
+%%
+f = figure(10); clf; f.Units  = 'centimeters';
+f.Position = [10,10,30,6];
+
+iMM(1) =  find([1:nstep]*struc.zstop/nstep>=0e-3,1);
+iMM(2) = find([1:nstep]*struc.zstop/nstep>=st,1);
+% iMM(3) = find([1:nstep]*struc.zstop/nstep>=2.5e-3,1);
+iMM(3) = find([1:nstep]*struc.zstop/nstep>=st + dr,1);
+
+if iMM(2)==iMM(3)&dr~=0;    iMM(3) = iMM(3) + 1; end
+iMM(4) = nstep;
+if ~opt; iis = 1:4; else iis = 1; end
+for i = iis
+    fi = focusTrack(iMM(i),:)==1;
+    subplot(1,max(iis),i)
+    hold on
+    plot(mod(thetap(iMM(i),fi) + taper(iMM(i)) - pi,2*pi) - pi,.511*(gammap(iMM(i),fi)-elec.gam0),'b.','MarkerSize',5);
+    plot(mod(thetap(iMM(i),focus)+ taper(iMM(i)) - pi,2*pi) - pi,.511*(gammap(iMM(i),focus)-elec.gam0),'r.','MarkerSize',5);
+    plot(mod(thetap(iMM(i),capt)+ taper(iMM(i)) - pi,2*pi) - pi,.511*(gammap(iMM(i),capt)-elec.gam0),'m.','MarkerSize',5);
+    xlim([-pi,pi])
+    hold off
+    box on
+    xlabel('\theta')
+    title(['z = ',num2str(floor(1e6*iMM(i)*struc.zstop/nstep)/1e3,2),' mm'])
+end
+
+% subplot(1,max(iis),1)
+ylabel('\Delta E (MeV)')
+L = legend('Current','Transmitted','Accelerated');
+L.ItemTokenSize(1) = 3;
+
+%% Ponderomotive Stability
+psi2        = pi*sign(psi_res) - psi_res;
+km_eq       = @(m,kp) (struc.k + (m +1).*kp);
+alpham_eq   = @(m,Ap,zi,kp) (struc.sf*las.G_gauss(zi).*besselj(m,Ap)./(km_eq(m,kp)*511e3));
+eta_eq      = @(m,psi,gam_res,Ap,zi,kp,psi_res) (sqrt(2.*alpham_eq(m,Ap,zi,kp).*gam_res.*(cos(psi) - cos(psi2(zi)) + (psi - psi2(zi)).*sin(psi_res))));
+
+psis        = linspace(0,2*pi,100);
+%%
+if animation
+%     F(nstep)=struct('cdata',[],'colormap',[]);
+        figure(40)
+    for i=1:10:nstep
+    clf;
+    plot(mod(thetap(i,capt)+taper(i)-pi,2*pi) - pi,.511*gammap(i,capt),'.'); hold on;
+    plot(mod(thetap(i,~capt)+taper(i)-pi,2*pi) - pi,.511*gammap(i,~capt),'.');
+    xlim([-pi pi])
+    if pondTag
+        etas        = eta_eq(res(i),psis,gam_res(i),Ap(i),i,2*pi/lambdap(i),psi_res(i));
+        gamsp        = .511*(etas+1)*gam_res(i);
+        gamsm        = .511*(-etas+1)*gam_res(i);
+        scatter(mod(psis,2*pi) - pi,gamsp,'.'); hold on;
+        scatter(mod(psis,2*pi) - pi,gamsm,'.'); hold off;
+    end
+    ylim([min(.511*gammap(end,:)),1.2*max(.511*gammap(end,:))])
+    title(['z = ', num2str(i*struc.zstop/nstep)])
+%     F(i) = getframe;
+    pause;
+    end
+        ylabel('Energy (MeV)')
+    xlabel('Phase (Rad)')
+%%
+%     F(nstep)=struct('cdata',[],'colormap',[]);
+    figure(40);clf;
+% 
+    for i=1:5:nstep
+    subplot(1,2,1)
+    plot((x(i,1==focusTrack(i,:)))*1e6,xp(i,1==focusTrack(i,:))*1e3,'.','MarkerSize',10);hold on;
+    plot((x(i,0==focusTrack(i,:)))*1e6,xp(i,0==focusTrack(i,:))*1e3,'.','MarkerSize',10);hold off;
+    title(['z = ', num2str(i*struc.zstop/nstep)])
+    ylim([-1,1])
+    xlim([-1e6*struc.gap/2*1.1,1e6*struc.gap/2*1.1])
+    xlabel('y [\mum]')
+    ylabel('y''[mrad]')
+    xline(-struc.gap*1e6*.5,'LineWidth',2);
+    xline(struc.gap*1e6*.5,'LineWidth',2);
+    ylim([-1,1])
+    subplot(1,2,2)
+    subplot(1,2,2)
+    plot(z*1e3,abs(las.phi-taper)); hold on;
+    scatter(z(i)*1e3,abs(las.phi(i)-taper(i))); hold off;
+    xlabel('z (mm)')
+    ylabel('Apf Phi (rad)')
+    pause(0.1)
+%     F(i) = getframe;
+    end
+%%     
+figure(45);clf;
+% 
+    for i=1:5:nstep
+    subplot(1,2,1)
+    plot((x(i,1==focusTrack(i,:)))*1e6,gammap(i,1==focusTrack(i,:))*.511,'.','MarkerSize',10);hold on;
+    plot((x(i,0==focusTrack(i,:)))*1e6,gammap(i,0==focusTrack(i,:))*.511,'.','MarkerSize',10);hold off;
+    title(['z = ', num2str(i*zstop/nstep)])
+    ylim([(gam_res(i)-0.4)*.511,(gam_res(i)+0.4)*.511])
+    xlim([-1,1])
+    xlabel('y (\mum)')
+    ylabel('Energy (MeV)')
+    xline(-struc.gap*1e6*.5,'LineWidth',2);
+    xline(struc.gap*1e6*.5,'LineWidth',2);
+    subplot(1,2,2)
+    subplot(1,2,2)
+    plot(z*1e3,abs(las.phi-taper)); hold on;
+    scatter(z(i)*1e3,abs(las.phi(i)-taper(i))); hold off;
+    xlabel('z (mm)')
+    ylabel('Apf Phi (rad)')
+%         F(i) = getframe;
+    end
+end


### PR DESCRIPTION
Run the shard_inputs file

I've separated out the input file from the simulation file (shard_main_noPlots) from the plotting file (shard_quickPlots), but running shard_inputs will run it all. 

In addition, the tapering calculation is done separately, so you can run it and then generate the correctly tapered lambdap for APF

genParts generates particles only inside the gap, but can also return the fraction of particles which are transmitted